### PR TITLE
Fix: Next/previous page button's URL

### DIFF
--- a/layouts/partials/pager.html
+++ b/layouts/partials/pager.html
@@ -4,7 +4,7 @@
 {{- if gt $pages 1 }}
   <div class = 'pager'>
     {{ if $paginator.HasPrev }}
-      <a href = '{{ $root }}{{ $paginator.Prev.URL }}'  class = ' pager_item pager_prev'></a>
+      <a href = '{{ $root }}.{{ $paginator.Prev.URL }}'  class = ' pager_item pager_prev'></a>
     {{ else }}
       <span class = ' pager_item pager_active pager_prev'></span>
     {{- end }}
@@ -12,7 +12,7 @@
     <span>{{ $paginator.PageNumber }} of {{ $pages }}</span>
 
     {{- if $paginator.HasNext -}}
-      <a href = '{{ $root }}{{ $paginator.Next.URL }}' class = ' pager_item pager_next'></a>
+      <a href = '{{ $root }}.{{ $paginator.Next.URL }}' class = ' pager_item pager_next'></a>
     {{ else -}}
       <span class = ' pager_item pager_active pager_next'></span>
     {{ end }}


### PR DESCRIPTION
When we tried to click next or previous page in archive page, pager didn't include the base URL.  
I finally found out that, there is a dot required. 
It is tested on Windows 10, RStudio, blogdown.