### PR TITLE
Fix typo in og:locale default value

### DIFF
--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -23,7 +23,7 @@
   {{- $image = $logo }}
 {{- end }}
 <meta name="keywords" content="{{ $st }}">
-<meta property="og:locale" content='{{ default "en)_US" $params.locale }}'>
+<meta property="og:locale" content='{{ default "en_US" $params.locale }}'>
 <meta property="og:type" content="article">
 <meta property="og:title" content="{{ .Title }}">
 <meta property="og:description" content="{{ $summary }}">


### PR DESCRIPTION
Fixed small typo in `og:locale` default value :) 