### PR TITLE
Update _components.sass

### DIFF
--- a/assets/sass/_components.sass
+++ b/assets/sass/_components.sass
@@ -94,7 +94,7 @@
   margin: 1rem 0 1.5rem
   display: inline-block
   padding: 7.5px 12.5px
-  background-color:var(--theme)
+  background-color: var(--theme)
   box-shadow: 0 1rem 4rem rgba(0,0,0,0.5)
   color: var(--light)
   text-align: center


### PR DESCRIPTION
Add a whitespace to fix broken css.
For now, GO BACK button in the 404 page is not shown correctly.