### PR TITLE
Improve the themes appearance on themes.gohugo.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a simple, minimalistic theme, which is inspired by [Apple's Newsroom page](https://www.apple.com/newsroom/). It uses *grid css*, *flexbox* & js (no jQuery, or related libraries).
 
-![Hugo Newsroom Theme](https://github.com/onweru/newsroom/blob/master/images/screenshot.png)
+![Hugo Newsroom Theme](https://raw.githubusercontent.com/onweru/newsroom/master/images/screenshot.png)
 
 ## Features
 
@@ -79,7 +79,7 @@ Follow the `exampleSite/`; specifically, the [content](https://github.com/onweru
 
 Today, operating systems have a system-wide __light ~ dark mode__ switch. Your website will adapt to the user's preferred lighting mode. Still, if the user wants to opt in or out of darkmode, there's a UI control for that too in the menu 😊.
 
-![Dark Mode](https://github.com/onweru/newsroom/blob/master/images/screenshot-dark.png)
+![Dark Mode](https://raw.githubusercontent.com/onweru/newsroom/master/images/screenshot-dark.png)
 
 #### Set a default lighting mode
 
@@ -91,11 +91,11 @@ If your site is built from a copy of the exampleSite, the field is already inclu
 
 ### Custom 404 Page
 
-![404 page](https://github.com/onweru/newsroom/blob/master/images/404.png)
+![404 page](https://raw.githubusercontent.com/onweru/newsroom/master/images/404.png)
 
 ### Syntax highlighting
 
-![404 page](https://github.com/onweru/newsroom/blob/master/images/syntax.png) 
+![Syntax Highlighting](https://raw.githubusercontent.com/onweru/newsroom/master/images/syntax.png) 
 
 If you wish, you can opt to [use Chroma](./exampleSite/config.toml#L17-L27).
 
@@ -110,7 +110,7 @@ disqusShortname = "yourdiscussshortname"
 
 From your disqus dashboard, set your scripts `color scheme` to __auto__. See screenshot below
 
-![](https://github.com/onweru/newsroom/blob/master/images/disqus-color-scheme.png)
+![](https://raw.githubusercontent.com/onweru/newsroom/master/images/disqus-color-scheme.png)
 
 ## Custom Shortcodes
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a simple, minimalistic theme, which is inspired by [Apple's Newsroom pag
 
 ### Deeplinks
 
-For all content published using markdown, deeplinks will be added to the pages so that you can share with precision :smiley: Just   hover on a heading and the link button will pop. Click it to copy.
+For all content published using markdown, deeplinks will be added to the pages so that you can share with precision 😃 Just   hover on a heading and the link button will pop. Click it to copy.
 
 ## Install Newsroom Theme
 

--- a/theme.toml
+++ b/theme.toml
@@ -3,10 +3,11 @@ license = "MIT"
 licenselink = "https://github.com/onweru/newsroom/blob/master/LICENSE.md"
 description = "A simple open source theme for publishing multi-purpose content"
 homepage = "https://github.com/onweru/newsroom"
+demosite = "https://rooms.netlify.app/"
 tags = ["blog", "simple", "dark", "minimalist", "fast", "disqus", "syntax highlighting"]
 features = ["blog", "simple", "dark", "minimalist", "fast", "disqus", "syntax highlighting"]
 min_version = "0.63.0"
 
 [author]
     name ="weru"
-    homepage = "https://github.com/onweru/newsroom"
+    homepage = "https://github.com/onweru"


### PR DESCRIPTION
This PR:
- makes the paths for images absolute, so that they can be displayed at https://themes.gohugo.io/themes/newsroom/. See https://github.com/gohugoio/hugoThemesSiteBuilder#use-absolute-paths-for-images.
- replaces one GitHub emoji declaration with the actual emoji so that it can be displayed at https://themes.gohugo.io/themes/newsroom/.
- adds the demosite key-value pair in theme.toml so that a direct link to the demo site can be generated at https://themes.gohugo.io/themes/newsroom/. See an example https://themes.gohugo.io/themes/hugo-book/.